### PR TITLE
Use Correct Mll in 2l Final State

### DIFF
--- a/TTHAnalysis/python/plotter/susy-sos/2los_cuts.txt
+++ b/TTHAnalysis/python/plotter/susy-sos/2los_cuts.txt
@@ -6,8 +6,8 @@ eventFilters	: $DATA{EventFilters} $MC{1}	; Disable=True
 dilep		: nLepGood == 2
 sublepPt	: (fabs(LepGood2_pdgId)==13 && LepGood2_pt > 3.5) || (fabs(LepGood2_pdgId)==11 && LepGood2_pt > 5)
 
-mll		: m2l > 4 && m2l < 50
-upsilonVeto	: m2l < 9 || m2l > 10.5
+mll		: minMllSFOS > 4 && minMllSFOS < 50
+upsilonVeto	: minMllSFOS < 9 || minMllSFOS > 10.5
 dilepPt		: pt_2(LepGood1_pt, LepGood1_phi, LepGood2_pt, LepGood2_phi) > 3 
 
 ISRjet		: Jet1_jetId >= 4

--- a/TTHAnalysis/python/plotter/susy-sos/2los_plots.txt
+++ b/TTHAnalysis/python/plotter/susy-sos/2los_plots.txt
@@ -1,10 +1,10 @@
 yields			: 1 : 1,-0.5,0.5; XTitle="Total Event Yields"
 #nVert: nVert	: 40,-0.5,41.5; XTitle="N_{vtx}"
 
-SR_2l_ewk		: m2l         : [4,10,20,30,50] ; XTitle="M(ll) [GeV]", Legend='TR', IncludeOverflows=True, LegendCutoff=1e-3, YMore=2.2
+SR_2l_ewk		: minMllSFOS         : [4,10,20,30,50] ; XTitle="M(ll) [GeV]", Legend='TR', IncludeOverflows=True, LegendCutoff=1e-3, YMore=2.2
 SR_2l_col		: LepGood1_pt : [5,12,20,30]    ; XTitle="Leading lepton p_{T} [GeV]", Legend='TR', LegendCutoff=1e-3, MoreY=2.8
 
-SR_2l_ewk_fine	: m2l         : 10,0,50         ; XTitle="M(ll) [GeV]", Legend='TR', IncludeOverflows=True, LegendCutoff=0, MoreY=2, LegendCutoff=1e-3
+SR_2l_ewk_fine	: minMllSFOS         : 10,0,50         ; XTitle="M(ll) [GeV]", Legend='TR', IncludeOverflows=True, LegendCutoff=0, MoreY=2, LegendCutoff=1e-3
 SR_2l_col_fine	: LepGood1_pt : 20,0,40         ; XTitle="Leading lepton p_{T} [GeV]", Legend='TR', LegendCutoff=1e-2
 
 ## Lepton variables
@@ -77,8 +77,8 @@ lep2ptext		: LepGood2_pt                                             : 9,0,180  
 #lep2_mcMatchID		: LepGood2_mcMatchId      : 30, 0, 30 ; XTitle="mcMatchID lep2"
 #lep1_genPartFlav	: LepGood1_genPartFlav : 30, 0,30; XTitle="Gen Part Flavor lep1"
 #lep2_genPartFlav	: LepGood2_genPartFlav : 30, 0,30; XTitle="Gen Part Flavor lep2"
-mll					: m2l         : 12,4,124 ; XTitle="M(ll) [GeV]", Legend='TL', LegendCutoff=0
-#fine_mll_50		: m2l: 23,4,50; XTitle="M(ll) [GeV]",LegendCutoff=1e-10
+mll					: minMllSFOS         : 12,4,124 ; XTitle="M(ll) [GeV]", Legend='TL', LegendCutoff=0
+#fine_mll_50		: minMllSFOS: 23,4,50; XTitle="M(ll) [GeV]",LegendCutoff=1e-10
 met					: MET_pt  : 20,50,450;  XTitle="p_{T}^{miss}  [GeV]", LegendCutoff=1e-3,Legend='TR' 
 metmm				: metmm_pt(LepGood1_pdgId, LepGood1_pt, LepGood1_phi, LepGood2_pdgId, LepGood2_pt, LepGood2_phi, MET_pt, MET_phi): 20,50,450;  XTitle="p_{T}^{miss\,corr}  [GeV]"
 #metMinusMetmm		: (MET_pt - metmm_pt(LepGood1_pdgId, LepGood1_pt, LepGood1_phi, LepGood2_pdgId, LepGood2_pt, LepGood2_phi, MET_pt, MET_phi) )	: 20,-100,100;  XTitle="p_{T}^{miss} - p_{T}^{miss\,corr}  [GeV]"

--- a/TTHAnalysis/python/plotter/susy-sos/sos_plots.py
+++ b/TTHAnalysis/python/plotter/susy-sos/sos_plots.py
@@ -71,7 +71,7 @@ def base(selection):
     if selection=='2los':
          GO="%s susy-sos/mca/mca-2los-%s.txt susy-sos/2los_cuts.txt "%(CORE, YEAR)
          if args.doWhat in ["plots","ntuple"]: GO+=" susy-sos/2los_plots.txt "
-         if args.doWhat in ["cards"]: GO+="  m2l [4,10,20,30,50] "
+         if args.doWhat in ["cards"]: GO+="  minMllSFOS [4,10,20,30,50] "
          
 
          if YEAR == "2016":


### PR DESCRIPTION
This PR contains a single commit making the substitution
`m2l` (computed on the first two LepGood) --> `minMllSFOS` (computed on the recleaned leptons)
in all files in the susy-sos directory.

Substitutions done based on the output of the command below in the `susy-sos` directory:
`grep -r 'm2l' .`